### PR TITLE
Removed unused interface

### DIFF
--- a/internal/workload/api/api.go
+++ b/internal/workload/api/api.go
@@ -1,15 +1,6 @@
 package api
 
-import v1 "k8s.io/api/core/v1"
-
 type WorkloadInfo struct {
 	Name   string
 	Status string
-}
-
-type WorkloadAPI interface {
-	List() ([]WorkloadInfo, error)
-	Remove(workloadName string) error
-	Run(workload *v1.Pod, manifestPath string) error
-	Start(workload *v1.Pod) error
 }


### PR DESCRIPTION
This PR removes unused interface to simplify the design of the `workload` package and sub-packages.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>