### PR TITLE
Mapping pod name from spec to Podman pod ID

### DIFF
--- a/internal/workload/api/api.go
+++ b/internal/workload/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 type WorkloadInfo struct {
+	Id     string
 	Name   string
 	Status string
 }

--- a/internal/workload/manager.go
+++ b/internal/workload/manager.go
@@ -10,39 +10,14 @@ import (
 
 	"git.sr.ht/~spc/go-log"
 	api2 "github.com/jakub-dzon/k4e-device-worker/internal/workload/api"
-	"github.com/jakub-dzon/k4e-device-worker/internal/workload/network"
-	podman2 "github.com/jakub-dzon/k4e-device-worker/internal/workload/podman"
 	"github.com/jakub-dzon/k4e-operator/models"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
-const nfTableName string = "edge"
-
 type WorkloadManager struct {
 	manifestsDir string
 	workloads    *workloadWrapper
-}
-
-// workloadWrapper manages the workload and its configuration on the device
-type workloadWrapper struct {
-	workloads *podman2.Podman
-	netfilter *network.Netfilter
-}
-
-func newWorkloadWrapper() (*workloadWrapper, error) {
-	newPodman, err := podman2.NewPodman()
-	if err != nil {
-		return nil, err
-	}
-	netfilter, err := network.NewNetfilter()
-	if err != nil {
-		return nil, err
-	}
-	return &workloadWrapper{
-		workloads: newPodman,
-		netfilter: netfilter,
-	}, nil
 }
 
 func NewWorkloadManager(configDir string) (*WorkloadManager, error) {
@@ -50,7 +25,7 @@ func NewWorkloadManager(configDir string) (*WorkloadManager, error) {
 	if err := os.MkdirAll(manifestsDir, 0755); err != nil {
 		return nil, fmt.Errorf("cannot create directory: %w", err)
 	}
-	wrapper, err := newWorkloadWrapper()
+	wrapper, err := newWorkloadWrapper(configDir)
 	if err != nil {
 		return nil, err
 	}
@@ -225,81 +200,4 @@ func (w *WorkloadManager) toPod(workload *models.Workload) (*v1.Pod, error) {
 	pod.Kind = "Pod"
 	pod.Name = workload.Name
 	return &pod, nil
-}
-
-func (ww workloadWrapper) Init() error {
-	return ww.netfilter.AddTable(nfTableName)
-}
-
-func (ww workloadWrapper) List() ([]api2.WorkloadInfo, error) {
-	return ww.workloads.List()
-}
-
-func (ww workloadWrapper) Remove(workloadName string) error {
-	if err := ww.workloads.Remove(workloadName); err != nil {
-		return err
-	}
-	if err := ww.netfilter.DeleteChain(nfTableName, workloadName); err != nil {
-		log.Errorf("failed to delete chain %[1]s from %s table for workload %[1]s", workloadName, nfTableName)
-	}
-	return nil
-}
-
-func (ww workloadWrapper) Run(workload *v1.Pod, manifestPath string) error {
-	if err := ww.applyNetworkConfiguration(workload); err != nil {
-		return err
-	}
-	if err := ww.workloads.Run(manifestPath); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (ww workloadWrapper) applyNetworkConfiguration(workload *v1.Pod) error {
-	hostPorts, err := getHostPorts(workload)
-	if err != nil {
-		log.Error(err)
-		return err
-	}
-	if len(hostPorts) == 0 {
-		return nil
-	}
-	// skip existence check since chain is not changed if already exists
-	if err := ww.netfilter.AddChain(nfTableName, workload.Name); err != nil {
-		return fmt.Errorf("failed to create chain for workload %s: %v", workload.Name, err)
-	}
-
-	// for workloads, a port will be opened for the pod based on hostPort
-	for _, p := range hostPorts {
-		rule := fmt.Sprintf("tcp dport %d ct state new,established counter accept", p)
-		if err := ww.netfilter.AddRule(nfTableName, workload.Name, rule); err != nil {
-			return fmt.Errorf("failed to add rule %s for workload %s: %v", rule, workload.Name, err)
-		}
-	}
-	return nil
-}
-
-func (ww workloadWrapper) Start(workload *v1.Pod) error {
-	ww.netfilter.DeleteChain(nfTableName, workload.Name)
-	if err := ww.applyNetworkConfiguration(workload); err != nil {
-		return err
-	}
-	if err := ww.workloads.Start(workload.Name); err != nil {
-		return err
-	}
-	return nil
-}
-
-func getHostPorts(workload *v1.Pod) ([]int32, error) {
-	hostPorts := []int32{}
-	for _, c := range workload.Spec.Containers {
-		for _, p := range c.Ports {
-			if p.HostPort > 0 && p.HostPort < 65536 {
-				hostPorts = append(hostPorts, p.HostPort)
-			} else {
-				return nil, fmt.Errorf("illegal host port number %d for container %s in workload %s", p.HostPort, c.Name, workload.Name)
-			}
-		}
-	}
-	return hostPorts, nil
 }

--- a/internal/workload/mapping.go
+++ b/internal/workload/mapping.go
@@ -1,0 +1,98 @@
+package workload
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path"
+	"sync"
+)
+
+type mapping struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type MappingRepository struct {
+	mappingFilePath string
+	idToName        map[string]string
+	nameToId        map[string]string
+	lock            sync.RWMutex
+}
+
+func NewMappingRepository(configDir string) (*MappingRepository, error) {
+	mappingFilePath := path.Join(configDir, "workload-mapping.json")
+
+	mappingJson, err := ioutil.ReadFile(mappingFilePath)
+	var mappings []mapping
+	if err == nil {
+		err := json.Unmarshal(mappingJson, &mappings)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	idToName := make(map[string]string)
+	nameToId := make(map[string]string)
+	for _, mapping := range mappings {
+		idToName[mapping.Id] = mapping.Name
+		nameToId[mapping.Name] = mapping.Id
+	}
+
+	return &MappingRepository{
+		mappingFilePath: mappingFilePath,
+		lock:            sync.RWMutex{},
+		idToName:        idToName,
+		nameToId:        nameToId,
+	}, nil
+}
+
+func (m *MappingRepository) Add(name, id string) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.idToName[id] = name
+	m.nameToId[name] = id
+
+	return m.persist()
+}
+
+func (m *MappingRepository) Remove(name string) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	id := m.nameToId[name]
+	delete(m.idToName, id)
+	delete(m.nameToId, name)
+
+	return m.persist()
+}
+
+func (m *MappingRepository) GetId(name string) string {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.nameToId[name]
+}
+
+func (m *MappingRepository) GetName(id string) string {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.idToName[id]
+}
+
+func (m *MappingRepository) persist() error {
+	var mappings []mapping
+	for id, name := range m.idToName {
+		mappings = append(mappings, mapping{Id: id, Name: name})
+	}
+	mappingsJson, err := json.Marshal(mappings)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(m.mappingFilePath, mappingsJson, 0640)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/workload/mapping/mapping.go
+++ b/internal/workload/mapping/mapping.go
@@ -1,4 +1,4 @@
-package workload
+package mapping
 
 import (
 	"encoding/json"
@@ -79,6 +79,12 @@ func (m *MappingRepository) GetName(id string) string {
 	defer m.lock.RUnlock()
 
 	return m.idToName[id]
+}
+
+func (m *MappingRepository) Persist() error {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.persist()
 }
 
 func (m *MappingRepository) persist() error {

--- a/internal/workload/wrapper.go
+++ b/internal/workload/wrapper.go
@@ -1,0 +1,130 @@
+package workload
+
+import (
+	"fmt"
+
+	"git.sr.ht/~spc/go-log"
+	api2 "github.com/jakub-dzon/k4e-device-worker/internal/workload/api"
+	"github.com/jakub-dzon/k4e-device-worker/internal/workload/network"
+	"github.com/jakub-dzon/k4e-device-worker/internal/workload/podman"
+	v1 "k8s.io/api/core/v1"
+)
+
+const nfTableName string = "edge"
+
+// workloadWrapper manages the workload and its configuration on the device
+type workloadWrapper struct {
+	workloads         *podman.Podman
+	netfilter         *network.Netfilter
+	mappingRepository *MappingRepository
+}
+
+func newWorkloadWrapper(configDir string) (*workloadWrapper, error) {
+	newPodman, err := podman.NewPodman()
+	if err != nil {
+		return nil, err
+	}
+	netfilter, err := network.NewNetfilter()
+	if err != nil {
+		return nil, err
+	}
+	mappingRepository, err := NewMappingRepository(configDir)
+	if err != nil {
+		return nil, err
+	}
+	return &workloadWrapper{
+		workloads:         newPodman,
+		netfilter:         netfilter,
+		mappingRepository: mappingRepository,
+	}, nil
+}
+
+func (ww workloadWrapper) Init() error {
+	return ww.netfilter.AddTable(nfTableName)
+}
+
+func (ww workloadWrapper) List() ([]api2.WorkloadInfo, error) {
+	infos, err := ww.workloads.List()
+	if err != nil {
+		return nil, err
+	}
+	for i := range infos {
+		infos[i].Name = ww.mappingRepository.GetName(infos[i].Id)
+	}
+	return infos, err
+}
+
+func (ww workloadWrapper) Remove(workloadName string) error {
+	if err := ww.workloads.Remove(ww.mappingRepository.GetId(workloadName)); err != nil {
+		return err
+	}
+	if err := ww.netfilter.DeleteChain(nfTableName, workloadName); err != nil {
+		log.Errorf("failed to delete chain %[1]s from %s table for workload %[1]s: %v", workloadName, nfTableName, err)
+	}
+	if err := ww.mappingRepository.Remove(workloadName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ww workloadWrapper) Run(workload *v1.Pod, manifestPath string) error {
+	if err := ww.applyNetworkConfiguration(workload); err != nil {
+		return err
+	}
+	podIds, err := ww.workloads.Run(manifestPath)
+	if err != nil {
+		return err
+	}
+	return ww.mappingRepository.Add(workload.Name, podIds[0])
+}
+
+func (ww workloadWrapper) applyNetworkConfiguration(workload *v1.Pod) error {
+	hostPorts, err := getHostPorts(workload)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	if len(hostPorts) == 0 {
+		return nil
+	}
+	// skip existence check since chain is not changed if already exists
+	if err := ww.netfilter.AddChain(nfTableName, workload.Name); err != nil {
+		return fmt.Errorf("failed to create chain for workload %s: %v", workload.Name, err)
+	}
+
+	// for workloads, a port will be opened for the pod based on hostPort
+	for _, p := range hostPorts {
+		rule := fmt.Sprintf("tcp dport %d ct state new,established counter accept", p)
+		if err := ww.netfilter.AddRule(nfTableName, workload.Name, rule); err != nil {
+			return fmt.Errorf("failed to add rule %s for workload %s: %v", rule, workload.Name, err)
+		}
+	}
+	return nil
+}
+
+func (ww workloadWrapper) Start(workload *v1.Pod) error {
+	ww.netfilter.DeleteChain(nfTableName, workload.Name)
+	if err := ww.applyNetworkConfiguration(workload); err != nil {
+		return err
+	}
+
+	podId := ww.mappingRepository.GetId(workload.Name)
+	if err := ww.workloads.Start(podId); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getHostPorts(workload *v1.Pod) ([]int32, error) {
+	hostPorts := []int32{}
+	for _, c := range workload.Spec.Containers {
+		for _, p := range c.Ports {
+			if p.HostPort > 0 && p.HostPort < 65536 {
+				hostPorts = append(hostPorts, p.HostPort)
+			} else {
+				return nil, fmt.Errorf("illegal host port number %d for container %s in workload %s", p.HostPort, c.Name, workload.Name)
+			}
+		}
+	}
+	return hostPorts, nil
+}


### PR DESCRIPTION
Fix for ECOPROJECT-234.

This PR introduces file-backed mapping between pod name defined in the pod specification and ID assigned to the Podman pod.

As part of this change set `workloadWrapper` has been moved to a separate file.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>