### PR TITLE
Parametrize podman socket name

### DIFF
--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -3,6 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
+	"os"
+	"path"
+	"time"
+
 	configuration2 "github.com/jakub-dzon/k4e-device-worker/internal/configuration"
 	hardware2 "github.com/jakub-dzon/k4e-device-worker/internal/hardware"
 	heartbeat2 "github.com/jakub-dzon/k4e-device-worker/internal/heartbeat"
@@ -10,10 +15,6 @@ import (
 	registration2 "github.com/jakub-dzon/k4e-device-worker/internal/registration"
 	"github.com/jakub-dzon/k4e-device-worker/internal/server"
 	workload2 "github.com/jakub-dzon/k4e-device-worker/internal/workload"
-	"net"
-	"os"
-	"path"
-	"time"
 
 	"git.sr.ht/~spc/go-log"
 
@@ -41,6 +42,10 @@ func main() {
 	baseConfigDir, ok := os.LookupEnv("BASE_CONFIG_DIR")
 	if !ok {
 		log.Fatal("Missing BASE_CONFIG_DIR environment variable")
+	}
+	podmanSocketName, ok := os.LookupEnv("PODMAND_SOCKET_NAME")
+	if !ok {
+		log.Fatal("Missing PODMAND_SOCKET_NAME environment variable")
 	}
 
 	// Dial the dispatcher on its well-known address.
@@ -78,7 +83,7 @@ func main() {
 	}
 	configManager := configuration2.NewConfigurationManager(configDir)
 
-	wl, err := workload2.NewWorkloadManager(configDir)
+	wl, err := workload2.NewWorkloadManager(configDir, podmanSocketName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/workload/manager.go
+++ b/internal/workload/manager.go
@@ -25,12 +25,12 @@ type podAndPath struct {
 	manifestPath string
 }
 
-func NewWorkloadManager(configDir string) (*WorkloadManager, error) {
+func NewWorkloadManager(configDir string, podmanSocketName string) (*WorkloadManager, error) {
 	manifestsDir := path.Join(configDir, "manifests")
 	if err := os.MkdirAll(manifestsDir, 0755); err != nil {
 		return nil, fmt.Errorf("cannot create directory: %w", err)
 	}
-	wrapper, err := newWorkloadWrapper(configDir)
+	wrapper, err := newWorkloadWrapper(configDir, podmanSocketName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workload/podman/podman.go
+++ b/internal/workload/podman/podman.go
@@ -2,6 +2,7 @@ package podman
 
 import (
 	"context"
+
 	"github.com/containers/podman/v2/pkg/bindings"
 	"github.com/containers/podman/v2/pkg/bindings/play"
 	"github.com/containers/podman/v2/pkg/bindings/pods"
@@ -13,8 +14,8 @@ type Podman struct {
 	podmanConnection context.Context
 }
 
-func NewPodman() (*Podman, error) {
-	podmanConnection, err := bindings.NewConnection(context.Background(), "unix://run/podman/podman.sock")
+func NewPodman(podmanSocketName string) (*Podman, error) {
+	podmanConnection, err := bindings.NewConnection(context.Background(), "unix://run/podman/"+podmanSocketName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workload/wrapper.go
+++ b/internal/workload/wrapper.go
@@ -2,6 +2,7 @@ package workload
 
 import (
 	"fmt"
+
 	"github.com/jakub-dzon/k4e-device-worker/internal/workload/mapping"
 
 	"git.sr.ht/~spc/go-log"
@@ -20,8 +21,8 @@ type workloadWrapper struct {
 	mappingRepository *mapping.MappingRepository
 }
 
-func newWorkloadWrapper(configDir string) (*workloadWrapper, error) {
-	newPodman, err := podman.NewPodman()
+func newWorkloadWrapper(configDir string, podmanSocketName string) (*workloadWrapper, error) {
+	newPodman, err := podman.NewPodman(podmanSocketName)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +124,7 @@ func (ww workloadWrapper) Start(workload *v1.Pod) error {
 	return nil
 }
 
-func (ww workloadWrapper) PersistConfiguration() error{
+func (ww workloadWrapper) PersistConfiguration() error {
 	return ww.mappingRepository.Persist()
 }
 


### PR DESCRIPTION
I wanted to run the agent on rhel8.2 and noticed that `podman.socket` is not there. I found it under different name:

```bash
ss -l -p | grep podman
u_str  LISTEN  0  128  /run/podman/io.podman 13964167  * 0  users:(("systemd",pid=1,fd=87))
```

This PR provides a way to customize it.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>