### PR TITLE
Attach export volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ make rpm
 To start the device-worker in clean (pairing) mode, make sure that following files are not present before starting
 yggdrasil:
 
-- `/usr/local/etc/yggdrasil/device/device-config.json`
-- `/usr/local/etc/yggdrasil/device/manifests/*`
+- `/var/local/yggdrasil/device/device-config.json`
+- `/var/local/yggdrasil/device/manifests/*`
 
 # Running
 

--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -23,6 +23,10 @@ import (
 
 var yggdDispatchSocketAddr string
 
+const (
+	defaultDataDir = "/var/local/yggdrasil"
+)
+
 func main() {
 	logLevel, ok := os.LookupEnv("LOG_LEVEL")
 	if !ok {
@@ -38,9 +42,11 @@ func main() {
 	if !ok {
 		log.Fatal("Missing YGG_SOCKET_ADDR environment variable")
 	}
-	baseConfigDir, ok := os.LookupEnv("BASE_CONFIG_DIR")
+
+	baseDataDir, ok := os.LookupEnv("BASE_DATA_DIR")
 	if !ok {
-		log.Fatal("Missing BASE_CONFIG_DIR environment variable")
+		log.Warnf("Missing BASE_DATA_DIR environment variable. Using default: %s", defaultDataDir)
+		baseDataDir = defaultDataDir
 	}
 
 	// Dial the dispatcher on its well-known address.
@@ -71,14 +77,14 @@ func main() {
 	}
 
 	// Register as a Worker service with gRPC and start accepting connections.
-	configDir := path.Join(baseConfigDir, "device")
-	log.Infof("Config dir: %s", configDir)
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	dataDir := path.Join(baseDataDir, "device")
+	log.Infof("Data directory: %s", dataDir)
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		log.Fatal(fmt.Errorf("cannot create directory: %w", err))
 	}
-	configManager := configuration2.NewConfigurationManager(configDir)
+	configManager := configuration2.NewConfigurationManager(dataDir)
 
-	wl, err := workload2.NewWorkloadManager(configDir)
+	wl, err := workload2.NewWorkloadManager(dataDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -35,8 +35,8 @@ type Manager struct {
 	initialConfig    atomic.Value
 }
 
-func NewConfigurationManager(configDir string) *Manager {
-	deviceConfigFile := path.Join(configDir, "device-config.json")
+func NewConfigurationManager(dataDir string) *Manager {
+	deviceConfigFile := path.Join(dataDir, "device-config.json")
 	log.Infof("Device config file: %s", deviceConfigFile)
 	file, err := ioutil.ReadFile(deviceConfigFile)
 	var deviceConfiguration models.DeviceConfigurationMessage

--- a/internal/volumes/volumes.go
+++ b/internal/volumes/volumes.go
@@ -1,0 +1,23 @@
+package volumes
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"path"
+)
+
+func HostPathVolume(volumesDir string, workloadName string) v1.Volume {
+	directoryOrCreate := v1.HostPathDirectoryOrCreate
+	return v1.Volume{
+		Name: "export-" + workloadName,
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Type: &directoryOrCreate,
+				Path: HostPathVolumePath(volumesDir, workloadName),
+			},
+		},
+	}
+}
+
+func HostPathVolumePath(volumesDir string, workloadName string) string {
+	return path.Join(volumesDir, workloadName)
+}

--- a/internal/workload/manager.go
+++ b/internal/workload/manager.go
@@ -27,16 +27,16 @@ type podAndPath struct {
 	manifestPath string
 }
 
-func NewWorkloadManager(configDir string) (*WorkloadManager, error) {
-	manifestsDir := path.Join(configDir, "manifests")
+func NewWorkloadManager(dataDir string) (*WorkloadManager, error) {
+	manifestsDir := path.Join(dataDir, "manifests")
 	if err := os.MkdirAll(manifestsDir, 0755); err != nil {
 		return nil, fmt.Errorf("cannot create directory: %w", err)
 	}
-	volumesDir := path.Join(configDir, "volumes")
+	volumesDir := path.Join(dataDir, "volumes")
 	if err := os.MkdirAll(volumesDir, 0755); err != nil {
 		return nil, fmt.Errorf("cannot create directory: %w", err)
 	}
-	wrapper, err := newWorkloadWrapper(configDir)
+	wrapper, err := newWorkloadWrapper(dataDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is a first step in implementing data transfer functionality on the device side. 

Code in this PR injects `/export` hostpath mount to each container in each pod specification.  Workloads are expected to put there  files that need to be transferred to the control plane storage.