### PR TITLE
Added build flags to allow running on RHEL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 LIBEXECDIR ?= /usr/libexec
 build:
 	mkdir -p ./bin
-	go build -o ./bin ./cmd/device-worker
+	CGO_ENABLED=0 go build -tags containers_image_openpgp -o ./bin ./cmd/device-worker
 
 install: build
 	sudo install -D -m 755 ./bin/device-worker $(LIBEXECDIR)/yggdrasil/device-worker


### PR DESCRIPTION
This PR changes the device-worker binary build to allow it to bu run on RHEL (with older GLIBC).

Signed-off-by: Jakub Dzon <jdzon@redhat.com>