### PR TITLE
Retry device registration until configuration is provided by the control plane

### DIFF
--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -93,7 +93,6 @@ func main() {
 
 	hw := hardware2.Hardware{}
 
-
 	dataMonitor := datatransfer.NewMonitor(wl, configManager)
 	wl.RegisterObserver(dataMonitor)
 	dataMonitor.Start()
@@ -102,17 +101,14 @@ func main() {
 	configManager.RegisterObserver(hbs)
 
 	deviceOs := os2.OS{}
-	reg := registration2.NewRegistration(&hw, &deviceOs, c)
+	reg := registration2.NewRegistration(&hw, &deviceOs, c, configManager)
 
 	s := grpc.NewServer()
 	pb.RegisterWorkerServer(s, server.NewDeviceServer(configManager))
-	if configManager.IsInitialConfig() {
-		err := reg.RegisterDevice()
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
+	if !configManager.IsInitialConfig() {
 		hbs.Start()
+	} else {
+		reg.RegisterDevice()
 	}
 
 	if err := s.Serve(l); err != nil {

--- a/internal/hardware/hardware.go
+++ b/internal/hardware/hardware.go
@@ -2,7 +2,6 @@ package hardware
 
 import (
 	"encoding/json"
-	"git.sr.ht/~spc/go-log"
 	"github.com/jakub-dzon/k4e-operator/models"
 	"github.com/openshift/assisted-installer-agent/src/inventory"
 )
@@ -13,7 +12,7 @@ type Hardware struct {
 func (s *Hardware) GetHardwareInformation() (*models.HardwareInfo, error) {
 	inv := inventory.ReadInventory()
 
-	// Instead of copying filed-by-filed marshal to JSON and unmarshal to other struct
+	// Instead of copying field-by-field marshal to JSON and unmarshal to other struct
 	inventoryJson, err := json.Marshal(inv)
 	if err != nil {
 		return nil, err
@@ -23,6 +22,6 @@ func (s *Hardware) GetHardwareInformation() (*models.HardwareInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("Hardware info: %s", inventoryJson)
+
 	return &hardwareInfo, nil
 }

--- a/internal/registration/registration.go
+++ b/internal/registration/registration.go
@@ -3,7 +3,9 @@ package registration
 import (
 	"context"
 	"encoding/json"
+	"git.sr.ht/~spc/go-log"
 	"github.com/google/uuid"
+	"github.com/jakub-dzon/k4e-device-worker/internal/configuration"
 	hardware2 "github.com/jakub-dzon/k4e-device-worker/internal/hardware"
 	os2 "github.com/jakub-dzon/k4e-device-worker/internal/os"
 	"github.com/jakub-dzon/k4e-operator/models"
@@ -11,21 +13,53 @@ import (
 	"time"
 )
 
+const (
+	retryAfter = 10
+)
+
 type Registration struct {
 	hardware         *hardware2.Hardware
 	os               *os2.OS
 	dispatcherClient pb.DispatcherClient
+	config           *configuration.Manager
+	RetryAfter       int64
 }
 
-func NewRegistration(hardware *hardware2.Hardware, os *os2.OS, dispatcherClient pb.DispatcherClient) *Registration {
+func NewRegistration(hardware *hardware2.Hardware, os *os2.OS, dispatcherClient pb.DispatcherClient, config *configuration.Manager) *Registration {
 	return &Registration{
 		hardware:         hardware,
 		os:               os,
 		dispatcherClient: dispatcherClient,
+		config:           config,
+		RetryAfter:       retryAfter,
 	}
 }
 
-func (r *Registration) RegisterDevice() error {
+func (r *Registration) RegisterDevice() {
+	err := r.registerDeviceOnce()
+	if err != nil {
+		log.Error(err)
+	}
+
+	go r.registerDeviceWithRetries(r.RetryAfter)
+}
+
+func (r *Registration) registerDeviceWithRetries(interval int64) {
+	ticker := time.NewTicker(time.Second * time.Duration(interval))
+	for range ticker.C {
+		if !r.config.IsInitialConfig() {
+			ticker.Stop()
+			break
+		}
+		log.Infof("Configuration has not been initialized yet. Sending registration request.")
+		err := r.registerDeviceOnce()
+		if err != nil {
+			log.Error(err)
+		}
+	}
+}
+
+func (r *Registration) registerDeviceOnce() error {
 	hardwareInformation, err := r.hardware.GetHardwareInformation()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR introduces registration retry logic in order to address ECOPROJECT-245. The registration requests will be sent to the control plane until device receives its configuration for the first time (as an indication of a successful registration). 

Registration operation is idempotent so it won't affect cluster-side state if request is sent multiple times.


Signed-off-by: Jakub Dzon <jdzon@redhat.com>