### PR TITLE
CI: Push rpm to fedora copr

### DIFF
--- a/.github/workflows/rpm.yaml
+++ b/.github/workflows/rpm.yaml
@@ -1,0 +1,36 @@
+---
+name: RPM build
+on:
+  push:
+    branches: [ main ]
+jobs:
+  build:
+    name: Submit a build from Fedora container
+    container: fedora:latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out proper version of sources
+        uses: actions/checkout@v1
+
+      - name: Install API token for copr-cli
+        env:
+          API_TOKEN_CONTENT: ${{ secrets.COPR_API_TOKEN }}
+        run: |
+          mkdir -p "$HOME/.config"
+          echo "$API_TOKEN_CONTENT" > "$HOME/.config/copr"
+
+      - name: Install tooling for source RPM build
+        run: |
+          dnf -y install @development-tools @rpm-development-tools
+          dnf -y install copr-cli make
+
+      - name: Build the source RPM
+        run: |
+          mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+          make rpm-tarball
+          make rpm-src
+
+      - name: Submit the build by uploading the source RPM
+        run: |
+          make rpm-copr

--- a/k4e-agent.spec
+++ b/k4e-agent.spec
@@ -4,7 +4,7 @@ Name:       k4e-agent
 Version:    1.0
 Release:    1%{?dist}
 Summary:    Agent application for the K4E (Kubernetes for Edge) solution
-
+ExclusiveArch: %{go_arches}
 Group:      K4E
 License:    GPL
 Source0:    https://github.com/jakub-dzon/%{name}-%{version}.tar.gz
@@ -25,9 +25,27 @@ The K4E agent communicates with the K4E control plane. It reports the status of 
 systemctl enable --now podman.socket
 systemctl enable --now nftables.service
 
+%prep 
+tar fx %{SOURCE0}
+
+%build
+cd k4e-agent-%{VERSION}
+export CGO_ENABLED=0 
+export GOFLAGS="-mod=vendor -tags=containers_image_openpgp"
+go build -o ./bin/device-worker ./cmd/device-worker
+
+%install
+cd k4e-agent-%{VERSION}
+mkdir -p %{buildroot}%{_libexecdir}/yggdrasil/
+install ./bin/device-worker %{buildroot}%{_libexecdir}/yggdrasil/device-worker
+
 %files
 %{_libexecdir}/yggdrasil/device-worker
 
 %changelog
+
+* Tue Nov 02 2021 Eloy Coto <eloycoto@acalustra.com> 1.0
+Compile Go code directly on the RPM spec, don't ship binaries.
+
 * Thu Sep 23 2021 Piotr Kliczewski - 1.0
 - TBD


### PR DESCRIPTION

    RPM was not created correctly, because it ships a binary when this is
    not allowed. With this change, the RPM is created from source, and
    src.rpm is created.

    Also, a new workflow is added, if any new commit on `main` branch, it'll
    build the src pacakge, and push the change to Fedora copr[0], where ARM
    and x86 builds are triggered.

    https://copr.fedorainfracloud.org/coprs/eloyocoto/k4e-test/packages/

    Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>

@TODO: I need to document how to use this repo, but want to work on r4e image first to get full context. 

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>