### PR TITLE
CI: RPM fix issues with Fedora 35 update.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ rpm-src:
 		--buildroot $(DIST_DIR) ./k4e-agent.spec
 
 rpm-copr: rpm-src
-	copr build eloyocoto/k4e-test $(HOME)/rpmbuild/SRPMS/k4e-agent-1.0-1.fc34.src.rpm
+	copr build eloyocoto/k4e-test $(HOME)/rpmbuild/SRPMS/k4e-agent-$(VERSION)-$(RELEASE).*.src.rpm
 
 rpm-build: rpm-src
-	rpmbuild $(RPMBUILD_OPTS) --rebuild $(HOME)/rpmbuild/SRPMS/k4e-agent-1.0-1.fc34.src.rpm
+	rpmbuild $(RPMBUILD_OPTS) --rebuild $(HOME)/rpmbuild/SRPMS/k4e-agent-$(VERSION)-$(RELEASE).*.src.rpm
 
 rpm: rpm-build
 


### PR DESCRIPTION
The result source RPM is no longer f34 src rpm.

Fix: https://github.com/jakub-dzon/k4e-device-worker/runs/4093859873?check_suite_focus=true

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>