### PR TITLE
Passing DEVICE_ID env variable to each container

### DIFF
--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -85,9 +85,14 @@ func main() {
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		log.Fatal(fmt.Errorf("cannot create directory: %w", err))
 	}
+	deviceId, ok := os.LookupEnv("DEVICE_ID")
+	if !ok {
+		log.Warn("DEVICE_ID environment variable has not been set")
+		deviceId = "unknown"
+	}
 	configManager := configuration2.NewConfigurationManager(dataDir)
 
-	wl, err := workload2.NewWorkloadManager(dataDir)
+	wl, err := workload2.NewWorkloadManager(dataDir, deviceId)
 	if err != nil {
 		log.Fatal("Cannot start Workload Manager, err: ", err)
 	}

--- a/internal/datatransfer/monitor_test.go
+++ b/internal/datatransfer/monitor_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Datatransfer", func() {
 		wkwMock.EXPECT().Init().Return(nil).AnyTimes()
 		wkwMock.EXPECT().PersistConfiguration().AnyTimes()
 
-		wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock)
+		wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock, "device-id-123")
 		Expect(err).NotTo(HaveOccurred(), "Cannot start the Workload Manager")
 
 		configManager = configuration.NewConfigurationManager(datadir)

--- a/internal/heartbeat/heartbeat_test.go
+++ b/internal/heartbeat/heartbeat_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Heartbeat", func() {
 		wkwMock.EXPECT().Init().Return(nil).AnyTimes()
 		wkwMock.EXPECT().PersistConfiguration().AnyTimes()
 
-		wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock)
+		wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock, "device-id-123")
 		Expect(err).NotTo(HaveOccurred(), "Cannot start the Workload Manager")
 
 		configManager = configuration.NewConfigurationManager(datadir)

--- a/internal/registration/registration_test.go
+++ b/internal/registration/registration_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Registration", func() {
 
 		dispatcherMock = registration.NewMockDispatcherClient(mockCtrl)
 
-		wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock)
+		wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock, "device-id-123")
 		Expect(err).NotTo(HaveOccurred(), "Cannot start the Workload Manager")
 
 		configManager = configuration.NewConfigurationManager(datadir)


### PR DESCRIPTION
This PR exposes `DEVICE_ID` variable equal to ID under which the device is registered with the control plane to each container in every Pod.