### PR TITLE
Datatransfer: Monitor force config load when device start

### DIFF
--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -99,7 +99,6 @@ func main() {
 	wl.RegisterObserver(dataMonitor)
 	configManager.RegisterObserver(dataMonitor)
 	dataMonitor.Start()
-
 	hbs := heartbeat2.NewHeartbeatService(dispatcherClient, configManager, wl, &hw, dataMonitor)
 
 	configManager.RegisterObserver(hbs)

--- a/internal/datatransfer/monitor_test.go
+++ b/internal/datatransfer/monitor_test.go
@@ -301,6 +301,33 @@ var _ = Describe("Datatransfer", func() {
 
 	})
 
+	Context("ForceUpdate", func() {
+		It("Works with valid configuration", func() {
+			// given
+			monitor := datatransfer.NewMonitor(wkManager, configManager)
+
+			// when
+			err := monitor.ForceUpdate()
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Cannot retrieve storage configuration", func() {
+			// given
+			monitor := datatransfer.NewMonitor(wkManager, configManager)
+			configManager.Update(models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{},
+			})
+
+			// when
+			err := monitor.ForceUpdate()
+
+			// then
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Context("Update", func() {
 		It("Works with valid configuration", func() {
 			// given


### PR DESCRIPTION
When device start, the datatransfer/monitor didn't get the update at
all, because Update() was not called.

With this change, on start, we force the start of config load.

Fix ECOPROJECT-376

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>