### PR TITLE
Log: disable datatime logging

### DIFF
--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -31,6 +31,8 @@ const (
 )
 
 func main() {
+	log.SetFlags(0) // No datatime, is already done on yggradsil server
+
 	logLevel, ok := os.LookupEnv("LOG_LEVEL")
 	if !ok {
 		logLevel = "ERROR"


### PR DESCRIPTION
With this change, yggradsil logs are a bit easy to understand, due to
the datatime on device worker does not add any information at all, and
add a lot of noise.

```
[yggd] 2021/12/16 13:12:00 [/usr/local/libexec/yggdrasil/device-worker] Data directory: /var/local/yggdrasil/device
[yggd] 2021/12/16 13:12:00 [/usr/local/libexec/yggdrasil/device-worker] Device config file: /var/local/yggdrasil/device/device-config.json
[yggd] 2021/12/16 13:12:00 [/usr/local/libexec/yggdrasil/device-worker] Cannot force-update datatransfer monitor: Cannot retrieve storage info
[yggd] 2021/12/16 13:12:00 [/usr/local/libexec/yggdrasil/device-worker] The heartbeat was started
```

Instead of:

```
[yggd] 2021/12/16 12:57:48 [/usr/local/libexec/yggdrasil/device-worker] 2021/12/16 12:57:48 Data directory: /var/local/yggdrasil/device
[yggd] 2021/12/16 12:57:48 [/usr/local/libexec/yggdrasil/device-worker] 2021/12/16 12:57:48 Device config file: /var/local/yggdrasil/device/device-config.json
[yggd] 2021/12/16 12:57:48 [/usr/local/libexec/yggdrasil/device-worker] 2021/12/16 12:57:48 Cannot force-update datatransfer monitor: Cannot retrieve storage info
[yggd] 2021/12/16 12:57:48 [/usr/local/libexec/yggdrasil/device-worker] 2021/12/16 12:57:48 The heartbeat was started
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>