### PR TITLE
Metrics scraper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.16.0
 	github.com/openshift/assisted-installer-agent v1.0.10-0.20211027185717-53b0eacfa147
+	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.32.1
 	github.com/prometheus/prometheus v1.8.2-0.20211217191541-41f1a8125e66
 	github.com/redhatinsights/yggdrasil v0.0.0-20210630184700-1d2d42276b6a
 	github.com/seqsense/s3sync v1.8.0

--- a/internal/metrics/scraper.go
+++ b/internal/metrics/scraper.go
@@ -1,0 +1,98 @@
+package metrics
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"io"
+	"net/http"
+)
+
+const (
+	acceptHeader = `application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
+)
+
+var (
+	UserAgent = fmt.Sprintf("k4e-device-worker")
+)
+
+type Scraper interface {
+	Scrape(ctx context.Context) (model.Vector, error)
+}
+
+type HTTPScraper struct {
+	client *http.Client
+	req    *http.Request
+}
+
+func NewHTTPScraper(url string) (*HTTPScraper, error) {
+	client := http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", acceptHeader)
+	req.Header.Add("Accept-Encoding", "gzip")
+	req.Header.Set("User-Agent", UserAgent)
+
+	return &HTTPScraper{
+		client: &client,
+		req:    req,
+	}, nil
+}
+
+func (s *HTTPScraper) Scrape(ctx context.Context) (model.Vector, error) {
+	resp, err := s.client.Do(s.req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("server returned HTTP status %s", resp.Status)
+	}
+
+	var reader io.Reader
+	switch resp.Header.Get("Content-Encoding") {
+	case "gzip":
+		gzipReader, err := gzip.NewReader(
+			bufio.NewReader(resp.Body),
+		)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			_ = gzipReader.Close()
+		}()
+		reader = gzipReader
+	default:
+		reader = resp.Body
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	decoder := expfmt.SampleDecoder{
+		Dec:  expfmt.NewDecoder(reader, expfmt.Format(contentType)),
+		Opts: &expfmt.DecodeOptions{Timestamp: model.Now()},
+	}
+
+	var allSamples model.Vector
+	for {
+		var mfSamples model.Vector
+		err := decoder.Decode(&mfSamples)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		allSamples = append(allSamples, mfSamples...)
+	}
+
+	return allSamples, nil
+}

--- a/internal/metrics/scraper_test.go
+++ b/internal/metrics/scraper_test.go
@@ -1,0 +1,132 @@
+package metrics_test
+
+import (
+	"compress/gzip"
+	"context"
+	"github.com/jakub-dzon/k4e-device-worker/internal/metrics"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/model"
+	"net/http"
+	"net/http/httptest"
+)
+
+const (
+	metricsPayload = `
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="prometheus",method="get"} 119 123456
+# HELP prometheus_samples_queue_capacity Capacity of the queue for unwritten samples.
+# TYPE prometheus_samples_queue_capacity gauge
+prometheus_samples_queue_capacity 4096 654321
+`
+)
+
+var (
+	expectedSamples = model.Vector{&model.Sample{
+		Metric: model.Metric{
+			model.MetricNameLabel: "http_requests_total",
+			"code":                "200",
+			"handler":             "prometheus",
+			"method":              "get",
+		},
+		Value:     119,
+		Timestamp: 123456,
+	},
+		&model.Sample{
+			Metric: model.Metric{
+				model.MetricNameLabel: "prometheus_samples_queue_capacity",
+			},
+			Value:     4096,
+			Timestamp: 654321,
+		},
+	}
+)
+
+var _ = Describe("Scraper", func() {
+	It("should scrape metrics", func() {
+		// given
+		server := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+				_, _ = w.Write([]byte(metricsPayload))
+			}),
+		)
+		defer server.Close()
+
+		scraper, err := metrics.NewHTTPScraper(server.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		samples, err := scraper.Scrape(context.TODO())
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(samples).To(HaveLen(2))
+		Expect(samples).To(ContainElements(expectedSamples))
+	})
+
+	It("should scrape metrics with gzip encoding", func() {
+		// given
+		server := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+				w.Header().Set("Content-Encoding", "gzip")
+				gzipWriter := gzip.NewWriter(w)
+				_, _ = gzipWriter.Write([]byte(metricsPayload))
+				_ = gzipWriter.Close()
+			}),
+		)
+		defer server.Close()
+
+		scraper, err := metrics.NewHTTPScraper(server.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		samples, err := scraper.Scrape(context.TODO())
+
+		// then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(samples).To(HaveLen(2))
+		Expect(samples).To(ContainElements(expectedSamples))
+	})
+
+	It("should report error on HTTP error", func() {
+		// given
+		server := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}),
+		)
+		defer server.Close()
+
+		scraper, err := metrics.NewHTTPScraper(server.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		_, err = scraper.Scrape(context.TODO())
+
+		// then
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should report error on metrics decoding error", func() {
+		// given
+		server := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
+				_, _ = w.Write([]byte("!!!!"))
+			}),
+		)
+		defer server.Close()
+
+		scraper, err := metrics.NewHTTPScraper(server.URL)
+		Expect(err).ToNot(HaveOccurred())
+
+		// when
+		_, err = scraper.Scrape(context.TODO())
+
+		// then
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -591,6 +591,7 @@ github.com/openshift/assisted-service/models
 github.com/ostreedev/ostree-go/pkg/glibobject
 github.com/ostreedev/ostree-go/pkg/otbuiltin
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -603,6 +604,7 @@ github.com/prometheus/client_golang/prometheus/testutil/promlint
 # github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.32.1
+## explicit
 github.com/prometheus/common/config
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg


### PR DESCRIPTION
This PR introduces `metrics.HTTPScraper` type that is responsible for calling given HTTP endpoint and scraping (retrieving and parsing) metrics in openmetrics format exposed by it. 