### PR TITLE
Config: RegisterObserver init config.

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -31,6 +31,7 @@ var (
 
 //go:generate mockgen -package=configuration -destination=configuration_mock.go . Observer
 type Observer interface {
+	Init(configuration models.DeviceConfigurationMessage) error
 	Update(configuration models.DeviceConfigurationMessage) error
 }
 
@@ -70,6 +71,12 @@ func NewConfigurationManager(dataDir string) *Manager {
 }
 
 func (m *Manager) RegisterObserver(observer Observer) {
+	// Always trigger the Init phase when register an observer to retrieve the
+	// current config.
+	err := observer.Init(*m.deviceConfiguration)
+	if err != nil {
+		log.Error("Running config init observer failed: ", err)
+	}
 	m.observers = append(m.observers, observer)
 }
 

--- a/internal/configuration/configuration_mock.go
+++ b/internal/configuration/configuration_mock.go
@@ -34,6 +34,20 @@ func (m *MockObserver) EXPECT() *MockObserverMockRecorder {
 	return m.recorder
 }
 
+// Init mocks base method.
+func (m *MockObserver) Init(arg0 models.DeviceConfigurationMessage) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Init", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Init indicates an expected call of Init.
+func (mr *MockObserverMockRecorder) Init(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockObserver)(nil).Init), arg0)
+}
+
 // Update mocks base method.
 func (m *MockObserver) Update(arg0 models.DeviceConfigurationMessage) error {
 	m.ctrl.T.Helper()

--- a/internal/datatransfer/monitor.go
+++ b/internal/datatransfer/monitor.go
@@ -39,11 +39,6 @@ func NewMonitor(workloadsManager *workload.WorkloadManager, configManager *confi
 }
 
 func (m *Monitor) Start() {
-	// Made this to force the config load in case there is no storage defined yet
-	// via Update() method.
-	if err := m.ForceUpdate(); err != nil {
-		log.Errorf("cannot force-update datatransfer monitor. DeviceID: %s; err: %v", m.workloads.GetDeviceID(), err)
-	}
 	go func() {
 		for range m.ticker.C {
 			m.syncPaths()
@@ -240,11 +235,8 @@ func (m *Monitor) storeLastUpdateTime(workloadName string) {
 	m.lastSuccessfulSyncTimes[workloadName] = time.Now()
 }
 
-func (m *Monitor) ForceUpdate() error {
-	config := m.config.GetDeviceConfiguration()
-	return m.Update(models.DeviceConfigurationMessage{
-		Configuration: &config,
-	})
+func (m *Monitor) Init(configuration models.DeviceConfigurationMessage) error {
+	return m.Update(configuration)
 }
 
 func (m *Monitor) Update(configuration models.DeviceConfigurationMessage) error {

--- a/internal/datatransfer/monitor_test.go
+++ b/internal/datatransfer/monitor_test.go
@@ -301,13 +301,13 @@ var _ = Describe("Datatransfer", func() {
 
 	})
 
-	Context("ForceUpdate", func() {
+	Context("Init", func() {
 		It("Works with valid configuration", func() {
 			// given
 			monitor := datatransfer.NewMonitor(wkManager, configManager)
 
 			// when
-			err := monitor.ForceUpdate()
+			err := monitor.Init(cfg)
 
 			// then
 			Expect(err).NotTo(HaveOccurred())
@@ -316,12 +316,10 @@ var _ = Describe("Datatransfer", func() {
 		It("Cannot retrieve storage configuration", func() {
 			// given
 			monitor := datatransfer.NewMonitor(wkManager, configManager)
-			configManager.Update(models.DeviceConfigurationMessage{
-				Configuration: &models.DeviceConfiguration{},
-			})
+			cfg.Configuration = nil
 
 			// when
-			err := monitor.ForceUpdate()
+			err := monitor.Init(cfg)
 
 			// then
 			Expect(err).To(HaveOccurred())

--- a/internal/heartbeat/heartbeat.go
+++ b/internal/heartbeat/heartbeat.go
@@ -98,6 +98,12 @@ func (s *Heartbeat) HasStarted() bool {
 	return s.ticker != nil
 }
 
+// Init no-op due to we need to an update from the source of truth in this
+// case(API)
+func (s *Heartbeat) Init(config models.DeviceConfigurationMessage) error {
+	return nil
+}
+
 func (s *Heartbeat) Update(config models.DeviceConfigurationMessage) error {
 	periodSeconds := s.getInterval(*config.Configuration)
 	log.Infof("reconfiguring ticker with interval: %v. DeviceID: %s", periodSeconds, s.data.workloadManager.GetDeviceID())

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -190,6 +190,10 @@ func (t *TSDB) AddVector(data model.Vector, labelsMap map[string]string) error {
 	return nil
 }
 
+func (t *TSDB) Init(config models.DeviceConfigurationMessage) error {
+	return t.Update(config)
+}
+
 func (t *TSDB) Update(config models.DeviceConfigurationMessage) error {
 	metricsConfiguration := config.Configuration.Metrics
 	maxBytes := DefaultMaxBytes

--- a/internal/metrics/system.go
+++ b/internal/metrics/system.go
@@ -1,11 +1,12 @@
 package metrics
 
 import (
-	"github.com/jakub-dzon/k4e-device-worker/internal/configuration"
-	"github.com/jakub-dzon/k4e-operator/models"
 	"reflect"
 	"sync/atomic"
 	"time"
+
+	"github.com/jakub-dzon/k4e-device-worker/internal/configuration"
+	"github.com/jakub-dzon/k4e-operator/models"
 )
 
 const (
@@ -37,6 +38,11 @@ func NewSystemMetrics(daemon MetricsDaemon, config DeviceConfigurationProvider) 
 	daemon.AddFilteredTarget(systemTargetName, []string{NodeExporterMetricsEndpoint}, time.Duration(expectedConfiguration.Interval)*time.Second, filter)
 	sm.latestConfig.Store(&expectedConfiguration)
 	return sm
+}
+
+func (sm *SystemMetrics) Init(config models.DeviceConfigurationMessage) error {
+	// No need due to the work is made on NewSystemMetrics
+	return nil
 }
 
 func (sm *SystemMetrics) Update(config models.DeviceConfigurationMessage) error {

--- a/internal/metrics/workload.go
+++ b/internal/metrics/workload.go
@@ -32,6 +32,10 @@ func (wrkM *WorkloadMetrics) getWorkload(workloadName string) *models.Workload {
 	return wrkM.workloadConfig[workloadName]
 }
 
+func (wrkM *WorkloadMetrics) Init(config models.DeviceConfigurationMessage) error {
+	return wrkM.Update(config)
+}
+
 func (wrkM *WorkloadMetrics) Update(config models.DeviceConfigurationMessage) error {
 	cfg := map[string]*models.Workload{}
 	for _, workload := range config.Workloads {

--- a/internal/workload/manager.go
+++ b/internal/workload/manager.go
@@ -106,6 +106,10 @@ func (w *WorkloadManager) GetDeviceID() string {
 	return w.deviceId
 }
 
+func (w *WorkloadManager) Init(configuration models.DeviceConfigurationMessage) error {
+	return w.Update(configuration)
+}
+
 func (w *WorkloadManager) Update(configuration models.DeviceConfigurationMessage) error {
 	w.managementLock.Lock()
 	defer w.managementLock.Unlock()


### PR DESCRIPTION
When yggd restart and any workload is already running, if the config
didn't change, it will not update the config to all registered observers.

With this commit, when an observer is created, has the option to send the
initial config to the Update() method, so the observers can run the initial
config and work against it.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>