### PR TITLE
Change systemd unit names to pod IDs

### DIFF
--- a/internal/workload/podman/podman.go
+++ b/internal/workload/podman/podman.go
@@ -3,8 +3,9 @@ package podman
 import (
 	"context"
 	"fmt"
-	"github.com/jakub-dzon/k4e-device-worker/internal/service"
 	"strings"
+
+	"github.com/jakub-dzon/k4e-device-worker/internal/service"
 
 	"git.sr.ht/~spc/go-log"
 	podmanEvents "github.com/containers/podman/v3/libpod/events"
@@ -282,14 +283,13 @@ func (p *podman) UpdateSecret(name, data string) error {
 	return p.CreateSecret(name, data)
 }
 
-func (p *podman) GenerateSystemdService(podName string, monitoringInterval uint) (service.Service, error) {
-	useName := true
-	report, err := generate.Systemd(p.podmanConnection, podName, &generate.SystemdOptions{UseName: &useName, RestartSec: &monitoringInterval})
+func (p *podman) GenerateSystemdService(podId string, monitoringInterval uint) (service.Service, error) {
+	report, err := generate.Systemd(p.podmanConnection, podId, &generate.SystemdOptions{RestartSec: &monitoringInterval})
 	if err != nil {
 		return nil, err
 	}
 
-	svc, err := service.NewSystemd(podName, "pod-", report.Units)
+	svc, err := service.NewSystemd(podId, "pod-", report.Units)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workload/wrapper_test.go
+++ b/internal/workload/wrapper_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Workload management", func() {
 			serviceManager.EXPECT().Add(svc).Return(nil)
 
 			mappingRepository.EXPECT().Add("pod1", "id1")
+			mappingRepository.EXPECT().GetId("pod1").Return("id1")
 
 			// when
 			err := wk.Run(pod, manifestPath, authFilePath)
@@ -76,6 +77,9 @@ var _ = Describe("Workload management", func() {
 
 			// given
 			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}
+
+			mappingRepository.EXPECT().Add("pod1", "id1")
+			mappingRepository.EXPECT().GetId("pod1").Return("id1")
 
 			newPodman.EXPECT().Run(manifestPath, authFilePath).Return([]*podman.PodReport{{Id: "id1"}}, nil)
 			newPodman.EXPECT().GenerateSystemdService(gomock.Any(), gomock.Any()).Return(svc, nil)
@@ -93,6 +97,9 @@ var _ = Describe("Workload management", func() {
 
 			// given
 			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}
+
+			mappingRepository.EXPECT().Add("pod1", "id1")
+			mappingRepository.EXPECT().GetId("pod1").Return("id1")
 
 			newPodman.EXPECT().Run(manifestPath, authFilePath).Return([]*podman.PodReport{{Id: "id1"}}, nil)
 			newPodman.EXPECT().GenerateSystemdService(gomock.Any(), gomock.Any()).Return(svc, nil)


### PR DESCRIPTION
This PR changes the systemd unit names to use pod IDs, because for some
use cases the pod names may not work.

For example when container name and pod name has same for different
podman version the podman generate different pod name.

Signed-off-by: Ondra Machacek <omachace@redhat.com>