### PR TITLE
Fix make dist

### DIFF
--- a/.github/workflows/rpm.yaml
+++ b/.github/workflows/rpm.yaml
@@ -27,7 +27,6 @@ jobs:
 
       - name: Build the source RPM
         run: |
-          mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
           make rpm-tarball
           make rpm-src
 

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ generate: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject
 	$(Q) go generate ./...
 
 .PHONY: vendor
+
 vendor:
 	go mod tidy
 	go mod vendor
@@ -100,7 +101,7 @@ rpm-tarball:
 	    | gzip > k4e-agent-$(VERSION).tar.gz
 
 rpm-src: rpm-tarball
-	cp k4e-agent-$(VERSION).tar.gz $(HOME)/rpmbuild/SOURCES/
+	install -D -m644 k4e-agent-$(VERSION).tar.gz --target-directory `rpmbuild -E %_sourcedir`
 	rpmbuild -bs \
 		-D "VERSION $(VERSION)" \
 		-D "RELEASE $(RELEASE)" \
@@ -114,11 +115,10 @@ rpm-build: rpm-src
 	rpmbuild $(RPMBUILD_OPTS) --rebuild $(HOME)/rpmbuild/SRPMS/k4e-agent-$(VERSION)-$(RELEASE).*.src.rpm
 
 rpm: ## Create rpm build
-rpm: rpm-build
+	RPMBUILD_OPTS=--target=x86_64 $(MAKE) rpm-build
 
 rpm-arm64: ## Create rpm build for arm64
-rpm-arm64: RPMBUILD_OPTS=--target=aarch64
-rpm-arm64: rpm-build
+	RPMBUILD_OPTS=--target=aarch64  $(MAKE) rpm-build
 
 dist: ## Create distribution packages
 dist: build build-arm64 rpm rpm-arm64


### PR DESCRIPTION
Fixes 2 issues in the Makefile:
* Failure to copy the .tar.gz to the `rpmbuild/SOURCES` directory as the directory does not exist at that point. Using the `install -D` command solves the issue.
  * How to reproduce:
    * Delete the ~/rpmbuild` directory
    * Run `make rpm-build`
    * Expected outcome: Successful build
    * Actual result: Failed to copy `.tar.gz` to `~/rpmbuild/SOURCES/`

* `make dist` only creates the rpms for a single architecture (when run the second time it will complete the remaining one). I suspect it has to do with the fact that both `rpm` and `rpm-arm64` depend on the same target `rpm-build` and `make` skips calling the `rpm-build` the second time as it has been already completed previously.
  *  How To reproduce:
     *  Delete the `~/rpmbuild` directory
     * Run `make dist`
     * Check that both aarch64 and x86_64 directories exist in `~/rpmbuild/RPMS`:
     * Expected result: 2 directories with an rpm in each directory.
     * Actual result: only the x86_64 directory and rpm exist

@eloycoto @jakub-dzon please review.